### PR TITLE
Added usernote functionality

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,26 @@
+{
+    "rules": {
+        "indent": [
+            0,
+            4
+        ],
+        "quotes": [
+            0,
+            "single"
+        ],
+        "linebreak-style": [
+            2,
+            "unix"
+        ],
+        "semi": [
+            2,
+            "always"
+        ],
+	"no-console": 0
+    },
+    "env": {
+        "es6": true,
+        "node": true
+    },
+    "extends": "eslint:recommended"
+}

--- a/commands/README.md
+++ b/commands/README.md
@@ -15,10 +15,29 @@ ___
 See `message_regex`. Note that unlike `message_regex`, `author_regex` is not required and defaults to `/.*/` (i.e. all authors). However, the bot will never reply to itself.
 
 ___
-`response` - `function(message_match, author_match, isPM)`
+`allow` - `function (isPM, isMod, isAuthenticated)`
 
-The function that gets called when your regexes match. `message_match` and `author_match` are arrays; they are the result of `message_regex.exec(message)` and `author_regex.exec(author)`, respectively. This means that you can use matching groups in `message_regex` and `author_regex` in order to parse messages more easily. `isPM` is a boolean indicating whether the function was called in response to a private message.
+This function allows the message to be filtered before it the `response()` function gets called. If it returns a falsy value, `response` will not get called. If the function is not provided, it defaults to:
 
-`response()` should return either a single string (for a one-line response) or an array of strings (for a multi-line response). It can also return a falsey value if the bot should not respond to the command.
+```javascript
+function defaultAllow(isPM, isMod, isAuthenticated) {
+  return !isPM || isMod && isAuthenticated; // Allow all non-PMs, but only allow PMs if the sender is an authenticated mod.
+}
+```
+
+* `isPM` - a `boolean` indicating whether the message was sent by PM
+* `isMod - a `boolean` indicating whether the sender of the message is in the mod database. Warning: If `config.disable_db` is true, `isMod` will always be `true`.
+* `isAuthenticated` - a `boolean` indicating whether the sender of the message is authenticated with NickServ.
+
+___
+`response` - `function(message_match, author_match, isPM, isMod, isAuthenticated)`
+
+This function that gets called when your regexes match. It should return either a single string (for a one-line response) or an array of strings (for a multi-line response). It can also return a falsey value if the bot should not respond to the command.
 
 If `response()` throws an error, it will be handled and printed to the console. If the error has an `error_message` property, this property will be sent to the IRC in lieu of a response. This could be useful to let the sender know that an error occured. For example, `throw {error_message: 'You forgot a parameter'};` will send 'You forgot a parameter' as a response.
+
+`message_match` - `Array` - the result of `message_regex.exec(message)`
+`author_match` - `Array` - the result of `author_regex.exec(author)`
+`isPM` - see `allow()` above
+`isMod` - see `allow()` above
+`isAuthenticated` - see `allow()` above

--- a/commands/checkball.js
+++ b/commands/checkball.js
@@ -1,9 +1,10 @@
+'use strict';
 var _ = require('lodash');
 var ball_data = require('../ball_data.json');
 var pokemon_list = _.keys(ball_data.legal);
-for (var i = 0; i < pokemon_list.length; i++) {
+for (let i = 0; i < pokemon_list.length; i++) {
   var parsed = [];
-  for (var j = 0; j < ball_data.ball_types.length; j++) {
+  for (let j = 0; j < ball_data.ball_types.length; j++) {
     var data = parseInt(ball_data.legal[pokemon_list[i]].charAt(j), 8);
     parsed.push({ball_name: ball_data.ball_types[j], legal: !!(data & 4), ha: !!(data & 2), breedable: !!(data & 1)});
   }
@@ -11,17 +12,17 @@ for (var i = 0; i < pokemon_list.length; i++) {
 }
 var pokemon_corrections = {'nidoran-m': 'nidoran♂', 'nidoran-f': 'nidoran♀', 'nidoran': 'nidoran♀'};
 var ball_corrections = {'poké': 'poke'};
-for (var i in ball_data.apricorn) {
+for (let i in ball_data.apricorn) {
   ball_corrections[ball_data.apricorn[i]] = 'apricorn';
 }
 function formatted_ball_name (ball_name) {
   return ball_name.toLowerCase() === 'poke' ? 'Poké' : _.capitalize(ball_name.toLowerCase());
-};
+}
 
 module.exports = {
   message_regex: /^.checkball ([^ ]+)(?: ([^ ]+))?/i,
   response: function (message_match) {
-    pokemon = pokemon_corrections[message_match[1].toLowerCase()] || message_match[1].toLowerCase();
+    let pokemon = pokemon_corrections[message_match[1].toLowerCase()] || message_match[1].toLowerCase();
     var pokemon_data = ball_data.legal[pokemon];
     if (!pokemon_data) {
       throw {error_message: "No Pokémon data found for '" + message_match[1] + "'."};

--- a/commands/lenny.js
+++ b/commands/lenny.js
@@ -1,10 +1,7 @@
 // ( ͡° ͜ʖ ͡°)‎
 module.exports = {
   message_regex: /^.lenny/,
-  author_regex: /.*/, // (No restriction on author. This line is not really necessary here, since /.*/ is the default anyway.)
-  response: function (message_match) {
-    /* Due to the way RegExp.prototype.exec() works in javascript, message_match[0] will be '.ping <some text>' (i.e. the entire match).
-    * The first matching group, <some text>, is message_match[1]. */
+  response: function () {
     return "( ͡° ͜ʖ ͡°)‎";
   }
 };

--- a/commands/shrug.js
+++ b/commands/shrug.js
@@ -1,10 +1,7 @@
 // ¯\_(ツ)_/¯
 module.exports = {
   message_regex: /^.shrug/,
-  author_regex: /.*/, // (No restriction on author. This line is not really necessary here, since /.*/ is the default anyway.)
-  response: function (message_match) {
-    /* Due to the way RegExp.prototype.exec() works in javascript, message_match[0] will be '.ping <some text>' (i.e. the entire match).
-    * The first matching group, <some text>, is message_match[1]. */
+  response: function () {
     return "¯\\_(ツ)_/¯";
   }
 };

--- a/commands/usernote.js
+++ b/commands/usernote.js
@@ -1,0 +1,170 @@
+'use strict';
+var NodeCache = require('node-cache');
+var _ = require('lodash');
+var moment = require('moment');
+var pako = require('pako');
+var reddit = require('../services/reddit.js');
+var parseArgs = require('minimist');
+var cache = new NodeCache({stdTTL: 900});
+const warningsToWords = {
+  none: ['blue', 'none'],
+  gooduser: ['green', 'misc', 'misc.', 'miscellaneous'],
+  spamwatch: ['pink', 'sketchy'],
+  spamwarn: ['purple', 'flair', 'fc'],
+  abusewarn: ['yellow', 'orange', 'minor warning', 'warn', 'warning'],
+  ban: ['red', 'major warning', 'tempban', 'light red'],
+  permban: ['brown', 'dark red', 'permaban', 'permanent ban'],
+  botban: ['black', 'old', 'general']
+};
+let warningTypes = _.keys(warningsToWords);
+var wordsToWarnings = {};
+for (let i = 0; i < warningTypes.length; i++) {
+  warningsToWords[warningTypes[i]].forEach(function (word) {
+    wordsToWarnings[word] = warningTypes[i];
+  });
+}
+
+module.exports = {
+  message_regex: /^.(?:usernote|tag) (.*)/,
+  allow: function (isPM, isAuthenticated, isMod) {
+    return !isPM && isAuthenticated && isMod;
+  },
+  response: function (message_match, author_match) {
+    /* Split into words, but keep quoted blocks together. Also parse reddit usernames and correctly.
+    e.g. '--option1 word --option2 "quoted block" otherword /u/someone /r/some_sub https://reddit.com/blah/'
+    --> ['--option1', 'word', '--option2', 'quoted block', 'otherword', '--user', 'someone', '--subreddit', 'some_sub', '--link', 'reddit.com/blah/'] */
+    let splitIntoWords = /(http(?:s)?:\/\/)|(\/u\/)|(\/r\/)|([^\s"]+)|(?:"((\\")?(?:[^"\\]|\\\\|\\")*)")+/g;
+    if (message_match[1].replace(splitIntoWords, '').trim()) {
+      throw {error_message: 'Error: invalid string.'};
+    }
+    let preparsedArgs = message_match[1].match(splitIntoWords).map(function (str) {
+      return str.replace(/\\\\/g, '\\').replace(/\\"/g, '"').replace(/^"(.*)"$/, '$1').replace(/^\/?u\/$/, '--user')
+        .replace(/^\/?r\/$/, '--subreddit').replace(/^http(s?):\/\/$/, '--link');
+    });
+    let parseSettings = {
+      default: {type: 'yellow'},
+      boolean: 'refresh-cache',
+      alias: {
+        sub: 'subreddit', s: 'subreddit', text: 'note', n: 'note', u: 'user', color: 'type', c: 'type', warning: 'type',
+        url: 'link', l: 'link', refresh: 'refresh-cache'
+      }
+    };
+    let args = parseArgs(preparsedArgs, parseSettings);
+    let command = args._.length ? args._[0].toLowerCase() : 'show';
+    args.subreddit = args.link || args.subreddit ? args.subreddit : 'pokemontrades';
+    if (command === 'show') {
+      if (!args.user) {
+        throw {error_message: 'Error: No user provided. To get the tags for a user, use `.tag /u/username`.'};
+      }
+      return getNotes(args.subreddit, args['refresh-cache']).then(function (parsed) {
+        let notes = _.find(parsed.notes, function (obj, name) {
+          if (name.toLowerCase() === args.user.toLowerCase()) {
+            args.user = name;
+            return true;
+          }
+        });
+        if (notes) {
+          return 'Notes on /u/' + args.user + ': ' + notes.ns.map((note, index) => (prettyPrintNote(note, args.subreddit, index))).join(', ');
+        }
+        return 'No notes found for /u/' + args.user + ' on /r/' + args.subreddit + '.';
+      });
+    }
+    if (command === 'add' || command === 'create' || command === 'append') {
+      let warning = wordsToWarnings[args.type];
+      if (!warning) {
+        throw {error_message: "Error: Unknown note type '" + args.type + "'"};
+      }
+      if (!args.note) {
+        throw {error_message: 'Error: Missing note text.'};
+      }
+      return getMissingInfo(args.user, args.subreddit, args.link).then(function (data) {
+        return addNote(author_match[0], data[0], data[1], args.note, warning, data[2], command === 'append').then(function (result) {
+          return 'Successfully added note on ' + data[0] + ': ' + prettyPrintNote(result, data[1]);
+        });
+      });
+    }
+  }
+};
+
+function decompress (blob) {
+  var inflate = new pako.Inflate({to: 'string'});
+  inflate.push(new Buffer(blob, 'base64').toString('binary'));
+  return JSON.parse(inflate.result);
+}
+function compress (notesObject) {
+  var deflate = new pako.Deflate({to: 'string'});
+  deflate.push(JSON.stringify(notesObject), true);
+  return (new Buffer(deflate.result.toString(), 'binary')).toString('base64');
+}
+function getNotes (subreddit, ignore_cache) {
+  let cached_notes = cache.get(subreddit);
+  if (cached_notes && !ignore_cache) {
+    return Promise.resolve(cached_notes);
+  }
+  return reddit.getWikiPage(subreddit, 'usernotes').then(function (compressed_notes) {
+    let pageObject = JSON.parse(compressed_notes);
+    let parsed = _(pageObject).assign({notes: decompress(pageObject.blob)}).omit('blob').value();
+    cache.set(subreddit, parsed);
+    return parsed;
+  });
+}
+function getMissingInfo (user, subreddit, url) {
+  let fetchUser, fetchSubreddit, formatted_link;
+  if (url) {
+    let parsed_url = url.match(/^(?:(?:http(?:s?):\/\/)?(?:\w*\.)?reddit.com)?\/(?:r\/(\w{1,21})\/comments\/(\w*)\/\w*\/(\w*)?)|(?:message\/messages\/(\w*))/);
+    if (!parsed_url) {
+      throw {error_message: 'Error: The provided URL is invalid.'};
+    }
+    if (parsed_url[4]) {
+      let fetchObject = reddit.getItemById('t4_' + parsed_url[4]);
+      fetchUser =  fetchObject.then(function (tree) {
+        return !user || tree.data.author.toLowerCase() === user.toLowerCase() ? tree.data.author : reddit.getCorrectUsername(user);
+      });
+      fetchSubreddit = subreddit || fetchObject.then(tree => (tree.data.subreddit));
+      formatted_link = 'm,' + parsed_url[4];
+    } else {
+      fetchUser = reddit.getItemById(parsed_url[3] ? 't1_' + parsed_url[3] : 't3_' + parsed_url[2]).then(response => (response.data.author));
+      fetchSubreddit = subreddit || parsed_url[1];
+      formatted_link = 'l,' + parsed_url[2] + (parsed_url[3] ? ',' + parsed_url[3] : '');
+    }
+  } else {
+    if (!user) {
+      throw {error_message: 'Error: Either a user or a URL is requred.'};
+    }
+    if (!subreddit) {
+      throw {error_message: 'Error: Either a subreddit or a URL is required.'};
+    }
+    fetchUser = reddit.getCorrectUsername(user);
+    fetchSubreddit = subreddit;
+  }
+  return Promise.all([fetchUser, fetchSubreddit, formatted_link]);
+}
+function addNote (modname, user, subreddit, noteText, warning, link_id, add_to_end) {
+  return getNotes(subreddit, true).then(function (parsed) {
+    let mods = parsed.constants.users;
+    let warnings = parsed.constants.warnings;
+    let notes = parsed.notes;
+    if (!notes[user]) {
+      notes[user] = {ns: []};
+    }
+    if (mods.indexOf(modname) === -1) {
+      mods.push(modname);
+    }
+    if (warnings.indexOf(warning) === -1) {
+      warnings.push(warning);
+    }
+    var newNote = {n: noteText, t: moment().unix(), m: mods.indexOf(modname), l: link_id, w: warnings.indexOf(warning)};
+    notes[user].ns[add_to_end ? 'push' : 'unshift'](newNote);
+    let newPageObject = _(parsed).assign({blob: compress(notes)}).omit('notes').value();
+    return reddit.editWikiPage(subreddit, 'usernotes', JSON.stringify(newPageObject), modname + ': Added a note on /u/' + user).then(function () {
+      cache.set(subreddit, parsed);
+      return newNote;
+    });
+  });
+}
+function prettyPrintNote (note, subreddit, index) {
+  let parsed = cache.get(subreddit);
+  return (index ? '(' + (index + 1) + ') ' : '') + _.capitalize(warningsToWords[parsed.constants.warnings[note.w]][0]) + ' note by ' +
+    parsed.constants.users[note.m] + ' at ' + moment.unix(note.t).utc().format("YYYY-MM-DD HH:mm:ss UTC") + (note.l ? ' on link https://reddit.com' +
+    (note.l.charAt(0) === 'l' ? ('/r/' + subreddit + '/comments/' + note.l.slice(2).replace(/,/g,'/-/')) : '/message/messages/' + note.l.slice(2)) : '') + ': "' + note.n + '"';
+}

--- a/config.default.js
+++ b/config.default.js
@@ -15,7 +15,8 @@ module.exports = {
   database: "porygon_bot",
   channels: ["#ircroom"],
   friendly: ["coolperson1", "coolperson2"],
-  commands : {
-    ".blah" : "bot response"
-  }
+  reddit_client_id: 'aaa',
+  reddit_client_secret: 'bbb',
+  reddit_refresh_token: 'ccc', // Scope: privatemessages read wikiedit wikiread
+  reddit_user_agent: 'Porygon IRC Helper'
 };

--- a/package.json
+++ b/package.json
@@ -18,9 +18,19 @@
   "dependencies": {
     "irc": "~0.3.0",
     "lodash": "^3.10.1",
+    "minimist": "^1.2.0",
+    "moment": "^2.10.6",
+    "node-cache": "^3.0.0",
     "node-sha1": "^1.0.1",
-    "promise-mysql": "^1.2.0"
+    "pako": "^0.2.8",
+    "promise-mysql": "^1.2.0",
+    "request-promise": "^1.0.2"
   },
   "repository": "https://github.com/pokemontrades/porygon-bot",
-  "bugs": "https://github.com/pokemontrades/porygon-bot/issues"
+  "bugs": "https://github.com/pokemontrades/porygon-bot/issues",
+  "devDependencies": {
+    "eslint-config-standard": "^4.4.0",
+    "eslint-plugin-standard": "^1.3.1",
+    "grunt-eslint": "^17.3.1"
+  }
 }

--- a/services/reddit.js
+++ b/services/reddit.js
@@ -1,0 +1,85 @@
+'use strict';
+var request = require('request-promise'),
+  moment = require('moment'),
+  _ = require('lodash'),
+  querystring = require('querystring'),
+  resetTime = moment().add(600, 'seconds'),
+  NodeCache = require('node-cache'),
+  tokenCache = new NodeCache({stdTTL: 3480}),
+  config = require('../config.js'),
+  left = 600;
+function refreshToken () {
+  var access_token = tokenCache.get(config.reddit_refresh_token);
+  if (access_token) {
+    return Promise.resolve(access_token);
+  }
+  return request.post({
+    url: 'https://www.reddit.com/api/v1/access_token',
+    headers: {
+      Authorization: 'Basic ' + new Buffer(config.reddit_client_id + ":" + config.reddit_client_secret).toString('base64'),
+      'User-Agent': config.reddit_user_agent,
+      'Content-Type': 'application/x-www-form-urlencoded'
+    },
+    body: 'grant_type=refresh_token&refresh_token=' + config.reddit_refresh_token,
+    json: true
+  }).then(function (response) {
+    tokenCache.set(config.reddit_refresh_token, response.access_token);
+    return response.access_token;
+  }, function (error) {
+    console.log('Error refreshing token: ' + error);
+    throw {error_message: 'Error communicating with reddit.'};
+  });
+}
+function makeRequest (requestType, url, data) {
+  return refreshToken().then(function (access_token) {
+    if (moment().isBefore(resetTime) && left < 2) {
+      throw 'Ratelimit reached';
+    }
+    data = _.assign(data || {}, {raw_json: 1});
+    return request({
+      url: 'https://oauth.reddit.com' + url + (requestType.toLowerCase() === 'get' ? '?' + querystring.encode(data) : ''),
+      headers: {
+        'User-Agent': config.reddit_user_agent,
+        Authorization: 'bearer ' + access_token
+      },
+      resolveWithFullResponse: true,
+      method: requestType,
+      formData: requestType.toLowerCase() === 'post' ? data : undefined
+    }).then(function (response) {
+      updateRateLimits(response);
+      return JSON.parse(response.body);
+    }, function (error) {
+      console.log('Error: request to ' + url + ' returned an error: ' + error);
+      throw {error_message: 'Error communicating with reddit.'};
+    });
+  });
+}
+function updateRateLimits (response) {
+  if (response && response.headers && response.headers['x-ratelimit-remaining'] && response.headers['x-ratelimit-reset']) {
+    left = response.headers['x-ratelimit-remaining'];
+    resetTime = moment().add(response.headers['x-ratelimit-reset'], 'seconds');
+  }
+}
+exports.getWikiPage = function (subreddit, page) {
+  return makeRequest('get', '/r/' + subreddit + '/wiki/' + page).then(response => (response.data.content_md));
+};
+exports.editWikiPage = function (subreddit, page, content, reason) {
+  return makeRequest('post', '/r/' + subreddit + '/api/wiki/edit', {content: content, page: page, reason: reason});
+};
+exports.getItemById = function (item_id) {
+  if (item_id.slice(0, 3) === 't4_') {
+    let findMessageInTree = function (tree) {
+      if (tree.data.name === item_id) {
+        return tree;
+      }
+      if (tree.data.replies) {
+        return _.find(tree.data.replies.data.children, findMessageInTree);
+      }
+    };
+    return makeRequest('get', '/message/messages/' + item_id.slice(3)).then(response => (response.data.children[0])).then(findMessageInTree);
+  }
+  return makeRequest('get', '/api/info', {id: item_id}).then(response => (response.data.children[0]));
+};
+exports.getCorrectUsername = function (name) { // Gets the correct capitalization for a reddit username, in order to store it properly in usernotes.
+  return makeRequest('get', '/user/' + name + '/about').then(response => (response.data.name));
+};


### PR DESCRIPTION
This is probably ready to try out. I should document it better at some point, but here are some things you can do:

___
```
.tag /u/actually_an_aardvark
```
// --> Returns the existing list of usernotes for /u/actually_an_aardvark on /r/pokemontrades.

___
```
.tag /u/actually_an_aardvark /r/SVExchange
```
// --> Returns the existing list of usernotes for /u/actually_an_aardvark on /r/SVExchange.

Note: In all of these examples, you can say `--user username` instead of `/u/username`. There are [similar aliases](/not-an-aardvark/porygon-bot/blob/master/commands/usernote.js#L48) for the other commands. Also, the order of the parameters (with the exception of "tag" at the beginning) doesn't matter.

___
```
.tag add  --color red --note "Doing evil things" https://www.reddit.com/r/pokemontrades/comments/3o99n0/test_post_please_ignore/
```
// --> Creates a note (with the red coloring) on that link. (The color defaults to yellow if it's not specified, and each one has a bunch of [aliases](/not-an-aardvark/porygon-bot/blob/master/commands/usernote.js#L9).) The bot will automatically figure out the correct user and subreddit by fetching the link (which can be either a comment, a post, or a modmail) from reddit. Alternatively you can specify the user explicitly, or even use a different user/subreddit:

```
.tag add /u/some_other_user https://www.reddit.com/r/pokemontrades/comments/3o99n0/test_post_please_ignore/ --note "Observing the thread suspiciously"
```
// --> This will create a note on /u/some_other_user that links to someone else's thread, which isn't possible with toolbox.

___
```
.tag append --note "something unimportant" --color green https://www.reddit.com/r/pokemontrades/comments/3o99n0/test_post_please_ignore/
```
// --> `append` does the same thing as `add`, but it adds the note at the *end* of the list, rather than the beginning (something else that isn't possible with toolbox). This can be useful if one wants to do record-keeping without changing the main usernote that appears next to a username.

___
```
.tag /u/some_username --refresh
```
// --> Gets the usernotes as normal, but also updates the cached notes. (By default, the notes are cached  for 15 minutes, and they automatically update if someone adds a note with the bot.)

___
By design, this command will only run for people in the database who have identified with NickServ. It will not work with PMs.

___
To make this run properly, you'll need to add a few things (reddit oauth stuff) to your config.js file. See the [config.default.js](/not-an-aardvark/porygon-bot/blob/master/config.default.js#L18) file for more details. Using something like [this](/xoru/easy-oauth) makes the process easier.