### PR TITLE
Refactor usernotes, add .tag delete

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,4 +14,4 @@ An IRC bot created by the /r/pokemontrades team for our use.
 * edit config.js and update information
 
 ## Usage
-* `node --harmony-destructuring bot.js`
+* `node --harmony-default-parameters --harmony-destructuring --harmony-proxies bot.js`

--- a/package.json
+++ b/package.json
@@ -16,15 +16,14 @@
     }
   ],
   "dependencies": {
+    "bluebird": "^3.3.4",
     "irc": "~0.3.0",
     "lodash": "^3.10.1",
     "minimist": "^1.2.0",
     "moment": "^2.10.6",
     "node-cache": "^3.0.0",
     "node-sha1": "^1.0.1",
-    "pako": "^0.2.8",
     "promise-mysql": "^1.2.0",
-    "request-promise": "^1.0.2",
     "snoowrap": "^0.9.3"
   },
   "repository": "https://github.com/pokemontrades/porygon-bot",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "node-sha1": "^1.0.1",
     "pako": "^0.2.8",
     "promise-mysql": "^1.2.0",
-    "request-promise": "^1.0.2"
+    "request-promise": "^1.0.2",
+    "snoowrap": "^0.9.3"
   },
   "repository": "https://github.com/pokemontrades/porygon-bot",
   "bugs": "https://github.com/pokemontrades/porygon-bot/issues",

--- a/services/reddit.js
+++ b/services/reddit.js
@@ -1,85 +1,9 @@
 'use strict';
-var request = require('request-promise'),
-  moment = require('moment'),
-  _ = require('lodash'),
-  querystring = require('querystring'),
-  resetTime = moment().add(600, 'seconds'),
-  NodeCache = require('node-cache'),
-  tokenCache = new NodeCache({stdTTL: 3480}),
-  config = require('../config.js'),
-  left = 600;
-function refreshToken () {
-  var access_token = tokenCache.get(config.reddit_refresh_token);
-  if (access_token) {
-    return Promise.resolve(access_token);
-  }
-  return request.post({
-    url: 'https://www.reddit.com/api/v1/access_token',
-    headers: {
-      Authorization: 'Basic ' + new Buffer(config.reddit_client_id + ":" + config.reddit_client_secret).toString('base64'),
-      'User-Agent': config.reddit_user_agent,
-      'Content-Type': 'application/x-www-form-urlencoded'
-    },
-    body: 'grant_type=refresh_token&refresh_token=' + config.reddit_refresh_token,
-    json: true
-  }).then(function (response) {
-    tokenCache.set(config.reddit_refresh_token, response.access_token);
-    return response.access_token;
-  }, function (error) {
-    console.log('Error refreshing token: ' + error);
-    throw {error_message: 'Error communicating with reddit.'};
-  });
-}
-function makeRequest (requestType, url, data) {
-  return refreshToken().then(function (access_token) {
-    if (moment().isBefore(resetTime) && left < 2) {
-      throw 'Ratelimit reached';
-    }
-    data = _.assign(data || {}, {raw_json: 1});
-    return request({
-      url: 'https://oauth.reddit.com' + url + (requestType.toLowerCase() === 'get' ? '?' + querystring.encode(data) : ''),
-      headers: {
-        'User-Agent': config.reddit_user_agent,
-        Authorization: 'bearer ' + access_token
-      },
-      resolveWithFullResponse: true,
-      method: requestType,
-      formData: requestType.toLowerCase() === 'post' ? data : undefined
-    }).then(function (response) {
-      updateRateLimits(response);
-      return JSON.parse(response.body);
-    }, function (error) {
-      console.log('Error: request to ' + url + ' returned an error: ' + error);
-      throw {error_message: 'Error communicating with reddit.'};
-    });
-  });
-}
-function updateRateLimits (response) {
-  if (response && response.headers && response.headers['x-ratelimit-remaining'] && response.headers['x-ratelimit-reset']) {
-    left = response.headers['x-ratelimit-remaining'];
-    resetTime = moment().add(response.headers['x-ratelimit-reset'], 'seconds');
-  }
-}
-exports.getWikiPage = function (subreddit, page) {
-  return makeRequest('get', '/r/' + subreddit + '/wiki/' + page).then(response => (response.data.content_md));
-};
-exports.editWikiPage = function (subreddit, page, content, reason) {
-  return makeRequest('post', '/r/' + subreddit + '/api/wiki/edit', {content: content, page: page, reason: reason});
-};
-exports.getItemById = function (item_id) {
-  if (item_id.slice(0, 3) === 't4_') {
-    let findMessageInTree = function (tree) {
-      if (tree.data.name === item_id) {
-        return tree;
-      }
-      if (tree.data.replies) {
-        return _.find(tree.data.replies.data.children, findMessageInTree);
-      }
-    };
-    return makeRequest('get', '/message/messages/' + item_id.slice(3)).then(response => (response.data.children[0])).then(findMessageInTree);
-  }
-  return makeRequest('get', '/api/info', {id: item_id}).then(response => (response.data.children[0]));
-};
-exports.getCorrectUsername = function (name) { // Gets the correct capitalization for a reddit username, in order to store it properly in usernotes.
-  return makeRequest('get', '/user/' + name + '/about').then(response => (response.data.name));
-};
+const config = require('../config');
+const snoowrap = require('snoowrap');
+module.exports = new snoowrap({
+  client_id: config.reddit_client_id,
+  client_secret: config.reddit_client_secret,
+  refresh_token: config.reddit_refresh_token,
+  user_agent: config.reddit_user_agent
+});


### PR DESCRIPTION
Example [here](https://www.irccloud.com/pastebin/2sHx8Aw2/)

`.tag delete <index> </u/user> [subreddit='/r/pokemontrades']`
Aliases: `rm`, `remove`

Deletes the note at the given *zero-based* index on the given user. For example, `.tag rm 1 /u/whoever /r/wherever` deletes the second note on /u/whoever.

`.tag undo-delete`

Restores a recently-deleted usernote, in case something was deleted by accident. This puts it back in the same spot on the list, with the same timestamp, etc. The cache containing deleted notes is stackable, so if two notes are deleted, using `undo-delete` twice will restore both of them.

---

Other changes:
* `usernotes.js` is a lot more readable now
* Switched to snoowrap for reddit API requests, which should make that process much less tedious if we want to do more of that sort of thing
* A few runtime flags are needed to run the bot properly: `--harmony-proxies`, `--harmony-destructuring`, `--harmony-default-parameters`. In theory it's possible to make the code not require those flags, but these features were all recently implemented into V8, so we probably won't need the flags for very long.