### PR TITLE
Tagging comment fix

### DIFF
--- a/commands/usernote.js
+++ b/commands/usernote.js
@@ -147,7 +147,7 @@ function getNotes (subreddit, {refresh = false} = {}) {
   });
 }
 function parseUrl (url) {
-  const urlParser = /^(?:(?:http(?:s?):\/\/)?(?:\w*\.)?reddit.com)?\/(?:r\/(\w{1,21})\/comments\/(\w*)(?:\/[\w-]*\/(\w*))?)|(?:message\/messages\/(\w*))/;
+  const urlParser = /^(?:(?:http(?:s?):\/\/)?(?:\w*\.)?reddit.com)?\/(?:r\/(\w{1,21})\/comments\/(\w*)(?:\/[^\/]*\/(\w*))?)|(?:message\/messages\/(\w*))/;
   const matched = url.match(urlParser);
   if (!matched) {
     throw {error_message: 'Error: The provided URL is invalid.'};


### PR DESCRIPTION
Changed the regex that extracts thread and comment IDs to properly handle threads with titles containing characters other than alphanumeric characters, dashes, and underscores. Previously, the bot would get confused and would tag the OP of such a thread if you tried to tag a comment in it.