### PR TITLE
Don't throw confusing errors if a the command's config is missing

### DIFF
--- a/services/usernote-helper.js
+++ b/services/usernote-helper.js
@@ -8,6 +8,9 @@ var moduleConfig = require('../config.js').usernoteConfig;
 
 module.exports = {
   getNotes (subreddit, fromChannel, {refresh = false} = {}) {
+    if (typeof subreddit !== 'string') {
+      throw {error_message: 'Error: No subreddit provided.'};
+    }
     checkAccess({channel: fromChannel, subreddit: subreddit});
     const cached_notes = cache.get(subreddit);
     if (cached_notes && !refresh) {


### PR DESCRIPTION
Previously, a TypeError would get thrown and the bot would fail silently if no default subreddit was configured.